### PR TITLE
Correct reference to immediate word (should be immediate byte)

### DIFF
--- a/decoding_gbz80_opcodes/Decoding Gamboy Z80 Opcodes.html
+++ b/decoding_gbz80_opcodes/Decoding Gamboy Z80 Opcodes.html
@@ -561,7 +561,7 @@
                 <td class="Z">z=0</td>
                 <td class="YTable"><table class="InsTableY">
                     <tbody><tr><td class="Q"></td><td class="Y">y=0..3</td><td>RET <span class="arg">cc[y]</span></td></tr>
-     <tr><td class="Q"></td><td class="Y">y=4</td><td>LD (<span class="arg">0xFF00 + nn</span>), A</td>
+     <tr><td class="Q"></td><td class="Y">y=4</td><td>LD (<span class="arg">0xFF00 + n</span>), A</td>
          <td class="Y">y=6</td><td>LD A, (<span class="arg">0xFF00 + n</span>)</td></tr>
      <tr><td class="Q"></td><td class="Y">y=5</td><td>ADD SP, <span class="arg">d</span></td><td class="Y">y=7</td><td>LD HL, SP<span class="arg">+ d</span></td></tr>
                 </tbody></table></td>


### PR DESCRIPTION
Opcode e0 is actually `LDH (a8),A` according to https://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html